### PR TITLE
Update 102-building-a-basic-workflow.md

### DIFF
--- a/cluck-university/rewst-foundations-10x/102-building-a-basic-workflow.md
+++ b/cluck-university/rewst-foundations-10x/102-building-a-basic-workflow.md
@@ -192,8 +192,6 @@ We jumped ahead to show how to trigger a workflow with a form. We now are going 
 **Add a Second Transition**
 
 1. **Click** the _Add_ (+) button on the _noop_ action to add a new transition.
-2. **Click and Drag** the transition from the _noop_ action to the _Remove Group Member_ action.
-   * To do this, you will need to hover over the gray circle under the new _On Success_ section you added.
 
 **Configure the Remove Transition**
 
@@ -238,6 +236,8 @@ We jumped ahead to show how to trigger a workflow with a form. We now are going 
 ```
 
 10. **Close** the editor.
+11. **Click and Drag** the transition from the _noop_ action to the _Remove Group Member_ action.
+   * To do this, you will need to hover over the gray circle under the new _Remove_ section you added.
 
 **Configure Add Group Member Action**
 


### PR DESCRIPTION
This might not be the best way to do it, but the instructions advise to drag the new transition to the Remove Group Member action, but that action isn't created until the next step. I moved it under point 10 in the next step, but I'm not sure that's the best place for it.