### PR TITLE
chore: fix missing exclamation

### DIFF
--- a/cluck-university/rewst-foundations-10x/103-jinja-essentials-for-workflow-automation.md
+++ b/cluck-university/rewst-foundations-10x/103-jinja-essentials-for-workflow-automation.md
@@ -8,7 +8,7 @@ description: Welcome to the third course in the Rewst Foundations series!
 
 Welcome to Rewst 103! In this course, we'll be talking about Jinja, the templating language that has become an essential tool for web developers and data engineers alike. In this article, we will explore the basics of Jinja, its syntax, and various use cases, with a focus on understanding the different use cases.
 
-When you've completed this training, [don't forget to get credit](https://app.rewst.io/form/ef9d5d9a-f4d0-4aaf-a7a0-c11a9b3b80a1)
+When you've completed this training, [don't forget to get credit!](https://app.rewst.io/form/ef9d5d9a-f4d0-4aaf-a7a0-c11a9b3b80a1)
 
 ## Watch the video and follow along with the steps below
 


### PR DESCRIPTION
Add exclamation point back to `don't forget to get credit` link text